### PR TITLE
v3.1: Deterministic Decision Runtime

### DIFF
--- a/basilisk/__init__.py
+++ b/basilisk/__init__.py
@@ -1,3 +1,3 @@
 """Basilisk — Professional modular security audit framework."""
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"

--- a/basilisk/decisions/__init__.py
+++ b/basilisk/decisions/__init__.py
@@ -1,0 +1,1 @@
+"""Decision tracing — explainable autonomous decision records."""

--- a/basilisk/decisions/decision.py
+++ b/basilisk/decisions/decision.py
@@ -1,0 +1,70 @@
+"""Decision model — structured record of every autonomous action choice."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field
+
+
+class ContextSnapshot(BaseModel):
+    """Graph state at the moment a decision was made."""
+
+    entity_count: int = 0
+    relation_count: int = 0
+    host_count: int = 0
+    service_count: int = 0
+    finding_count: int = 0
+    gap_count: int = 0
+    elapsed_seconds: float = 0.0
+    step: int = 0
+
+
+class EvaluatedOption(BaseModel):
+    """A single candidate considered during decision-making."""
+
+    capability_name: str
+    plugin_name: str
+    target_entity_id: str
+    target_host: str
+    score: float
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
+    reason: str = ""
+    was_chosen: bool = False
+
+
+class Decision(BaseModel):
+    """Complete record of an autonomous decision with pre/post execution data.
+
+    Created BEFORE execution (intent), updated AFTER execution (outcome).
+    Deterministic ID derived from step + timestamp + plugin + target.
+    """
+
+    id: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    step: int = 0
+    goal: str = ""                       # gap.missing (e.g. "services")
+    goal_description: str = ""           # gap.description
+    goal_priority: float = 0.0           # gap.priority
+    triggering_entity_id: str = ""
+    context: ContextSnapshot = Field(default_factory=ContextSnapshot)
+    evaluated_options: list[EvaluatedOption] = Field(default_factory=list)
+    chosen_capability: str = ""
+    chosen_plugin: str = ""
+    chosen_target: str = ""
+    chosen_score: float = 0.0
+    reasoning_trace: str = ""
+
+    # Filled after execution
+    outcome_observations: int = 0
+    outcome_new_entities: int = 0
+    outcome_confidence_delta: float = 0.0
+    outcome_duration: float = 0.0
+    was_productive: bool = False
+
+    @staticmethod
+    def make_id(step: int, timestamp: datetime, plugin: str, target: str) -> str:
+        """Deterministic ID from step + timestamp + plugin + target."""
+        raw = f"{step}:{timestamp.isoformat()}:{plugin}:{target}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]

--- a/basilisk/events/bus.py
+++ b/basilisk/events/bus.py
@@ -23,6 +23,7 @@ class EventType(StrEnum):
     PLUGIN_FINISHED = "plugin_finished"
     GAP_DETECTED = "gap_detected"
     STEP_COMPLETED = "step_completed"
+    DECISION_MADE = "decision_made"
 
 
 @dataclass

--- a/basilisk/knowledge/state.py
+++ b/basilisk/knowledge/state.py
@@ -1,0 +1,94 @@
+"""Knowledge state — delta-tracking wrapper around KnowledgeGraph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from basilisk.decisions.decision import ContextSnapshot
+from basilisk.knowledge.entities import Entity
+from basilisk.knowledge.graph import KnowledgeGraph
+from basilisk.observations.observation import Observation
+
+if TYPE_CHECKING:
+    from basilisk.orchestrator.planner import KnowledgeGap, Planner
+
+
+@dataclass
+class ObservationOutcome:
+    """Result of applying a single observation — captures before/after confidence."""
+
+    entity_id: str
+    was_new: bool
+    confidence_before: float
+    confidence_after: float
+
+    @property
+    def confidence_delta(self) -> float:
+        return self.confidence_after - self.confidence_before
+
+
+class KnowledgeState:
+    """Delta-tracking wrapper around KnowledgeGraph.
+
+    Reuses the graph's merge logic but captures confidence before/after
+    for every observation applied. Does NOT replace the graph — wraps it.
+    """
+
+    def __init__(
+        self, graph: KnowledgeGraph, planner: Planner | None = None,
+    ) -> None:
+        self.graph = graph
+        self._planner = planner
+
+    def apply_observation(self, obs: Observation) -> ObservationOutcome:
+        """Apply observation to graph and return delta information."""
+        entity_id = Entity.make_id(obs.entity_type, **obs.key_fields)
+        now = datetime.now(UTC)
+
+        existing = self.graph.get(entity_id)
+        confidence_before = existing.confidence if existing else 0.0
+        was_new = existing is None
+
+        entity = Entity(
+            id=entity_id,
+            type=obs.entity_type,
+            data=obs.entity_data,
+            confidence=obs.confidence,
+            evidence=[obs.evidence] if obs.evidence else [],
+            first_seen=now,
+            last_seen=now,
+        )
+
+        merged = self.graph.add_entity(entity)
+        confidence_after = merged.confidence
+
+        if obs.relation:
+            self.graph.add_relation(obs.relation)
+
+        return ObservationOutcome(
+            entity_id=entity_id,
+            was_new=was_new,
+            confidence_before=confidence_before,
+            confidence_after=confidence_after,
+        )
+
+    def snapshot(self, step: int, elapsed: float, gap_count: int) -> ContextSnapshot:
+        """Create a deterministic snapshot of current graph state."""
+        return ContextSnapshot(
+            entity_count=self.graph.entity_count,
+            relation_count=self.graph.relation_count,
+            host_count=len(self.graph.hosts()),
+            service_count=len(self.graph.services()),
+            finding_count=len(self.graph.findings()),
+            gap_count=gap_count,
+            elapsed_seconds=elapsed,
+            step=step,
+        )
+
+    def find_gaps(self) -> list[KnowledgeGap]:
+        """Delegate gap detection to planner or graph."""
+        if self._planner:
+            return self._planner.find_gaps(self.graph)
+        return self.graph.find_missing_knowledge()

--- a/basilisk/memory/__init__.py
+++ b/basilisk/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Decision memory — history tracking and repetition penalty."""

--- a/basilisk/memory/history.py
+++ b/basilisk/memory/history.py
@@ -1,0 +1,130 @@
+"""Decision history — log, repetition penalty, and persistence."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from basilisk.decisions.decision import Decision
+
+
+class History:
+    """In-memory decision log with repetition penalty and JSON persistence.
+
+    Records every autonomous decision, tracks outcomes, and computes
+    penalties for repeated or unproductive actions.
+    """
+
+    def __init__(self) -> None:
+        self._decisions: list[Decision] = []
+        self._by_id: dict[str, Decision] = {}
+        # Index: plugin_name → list of decisions for O(1) penalty lookup
+        self._by_plugin: dict[str, list[Decision]] = defaultdict(list)
+
+    def record(self, decision: Decision) -> None:
+        """Record a new decision (before execution)."""
+        self._decisions.append(decision)
+        self._by_id[decision.id] = decision
+        self._by_plugin[decision.chosen_plugin].append(decision)
+
+    def update_outcome(
+        self,
+        decision_id: str,
+        *,
+        observations: int = 0,
+        new_entities: int = 0,
+        confidence_delta: float = 0.0,
+        duration: float = 0.0,
+    ) -> None:
+        """Update a decision with post-execution outcome metrics."""
+        decision = self._by_id.get(decision_id)
+        if not decision:
+            return
+        decision.outcome_observations = observations
+        decision.outcome_new_entities = new_entities
+        decision.outcome_confidence_delta = confidence_delta
+        decision.outcome_duration = duration
+        decision.was_productive = new_entities > 0 or confidence_delta > 0.01
+
+    def repetition_penalty(
+        self,
+        plugin_name: str,
+        target_entity_id: str,
+        *,
+        base_penalty: float = 5.0,
+        unproductive_multiplier: float = 2.0,
+    ) -> float:
+        """Compute repetition penalty for a (plugin, target) pair.
+
+        Formula: base * (2x if prior was unproductive) * time_decay
+        where time_decay = 1 / (1 + 0.1 * steps_since).
+        Returns 0.0 if never executed before.
+        """
+        past = self._by_plugin.get(plugin_name)
+        if not past:
+            return 0.0
+
+        # Find most recent decision for this (plugin, target)
+        relevant = [d for d in past if d.triggering_entity_id == target_entity_id]
+        if not relevant:
+            return 0.0
+
+        latest = relevant[-1]
+        steps_since = max(len(self._decisions) - self._decisions.index(latest) - 1, 0)
+        time_decay = 1.0 / (1.0 + 0.1 * steps_since)
+
+        penalty = base_penalty * time_decay
+        if not latest.was_productive:
+            penalty *= unproductive_multiplier
+
+        return penalty
+
+    def save(self, path: Path) -> None:
+        """Persist decision history to JSON file."""
+        data = [d.model_dump(mode="json") for d in self._decisions]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> History:
+        """Load decision history from JSON file."""
+        history = cls()
+        if not path.exists():
+            return history
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        for item in raw:
+            decision = Decision.model_validate(item)
+            history.record(decision)
+            # Restore was_productive based on loaded data
+            if decision.outcome_new_entities > 0 or decision.outcome_confidence_delta > 0.01:
+                decision.was_productive = True
+        return history
+
+    @property
+    def decisions(self) -> list[Decision]:
+        return list(self._decisions)
+
+    @property
+    def productive_count(self) -> int:
+        return sum(1 for d in self._decisions if d.was_productive)
+
+    @property
+    def total_confidence_gained(self) -> float:
+        return sum(d.outcome_confidence_delta for d in self._decisions)
+
+    def summary(self) -> str:
+        """Human-readable summary of the decision history."""
+        total = len(self._decisions)
+        productive = self.productive_count
+        confidence = self.total_confidence_gained
+        if total == 0:
+            return "No decisions recorded."
+        ratio = productive / total * 100
+        return (
+            f"{total} decisions, {productive} productive ({ratio:.0f}%), "
+            f"total confidence gained: {confidence:.3f}"
+        )
+
+    def __len__(self) -> int:
+        return len(self._decisions)

--- a/basilisk/scoring/scorer.py
+++ b/basilisk/scoring/scorer.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
 
 from basilisk.capabilities.capability import Capability
 from basilisk.knowledge.entities import Entity
 from basilisk.knowledge.graph import KnowledgeGraph
+
+if TYPE_CHECKING:
+    from basilisk.memory.history import History
 
 
 class ScoredCapability(BaseModel):
@@ -16,6 +21,7 @@ class ScoredCapability(BaseModel):
     target_entity: Entity
     score: float
     reason: str
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
 
 
 class Scorer:
@@ -24,8 +30,11 @@ class Scorer:
     priority = (novelty * knowledge_gain) / (cost + noise + repetition_penalty)
     """
 
-    def __init__(self, graph: KnowledgeGraph) -> None:
+    def __init__(
+        self, graph: KnowledgeGraph, history: History | None = None,
+    ) -> None:
         self.graph = graph
+        self._history = history
 
     def rank(
         self, candidates: list[tuple[Capability, Entity]],
@@ -33,25 +42,28 @@ class Scorer:
         """Score all candidates and return sorted by score descending."""
         scored = []
         for cap, entity in candidates:
-            score = self._score_one(cap, entity)
+            score, breakdown = self._score_one(cap, entity)
             reason = self._explain(cap, entity, score)
             scored.append(ScoredCapability(
                 capability=cap,
                 target_entity=entity,
                 score=score,
                 reason=reason,
+                score_breakdown=breakdown,
             ))
         scored.sort(key=lambda s: s.score, reverse=True)
         return scored
 
-    def _score_one(self, cap: Capability, entity: Entity) -> float:
+    def _score_one(self, cap: Capability, entity: Entity) -> tuple[float, dict[str, float]]:
         """Compute priority score for a single (capability, entity) pair.
+
+        Returns (score, breakdown_dict).
 
         novelty: 1.0 if entity never explored by this cap, decays with observation_count
         knowledge_gain: len(produces) * (1 - confidence)
         cost: cost_score (1-10)
         noise: noise_score (1-10)
-        repetition_penalty: 5.0 if same cap+entity was run before, else 0
+        repetition_penalty: from History if available, else binary 5.0 from graph
         """
         # Novelty — higher when entity has fewer observations
         novelty = 1.0 / (1.0 + (entity.observation_count - 1) * 0.3)
@@ -60,15 +72,33 @@ class Scorer:
         knowledge_gain = len(cap.produces_knowledge) * (1.0 - entity.confidence)
         knowledge_gain = max(knowledge_gain, 0.1)  # minimum gain
 
-        # Repetition penalty
+        # Repetition penalty — prefer History when available
         fingerprint = f"{cap.plugin_name}:{entity.id}"
-        repetition_penalty = 5.0 if self.graph.was_executed(fingerprint) else 0.0
+        if self._history:
+            repetition_penalty = self._history.repetition_penalty(
+                cap.plugin_name, entity.id,
+            )
+        else:
+            repetition_penalty = 5.0 if self.graph.was_executed(fingerprint) else 0.0
 
         # Cost + noise baseline
-        denominator = cap.cost_score + cap.noise_score + repetition_penalty
+        cost = cap.cost_score
+        noise = cap.noise_score
+        denominator = cost + noise + repetition_penalty
         denominator = max(denominator, 0.1)  # avoid division by zero
 
-        return (novelty * knowledge_gain) / denominator
+        raw_score = (novelty * knowledge_gain) / denominator
+
+        breakdown = {
+            "novelty": novelty,
+            "knowledge_gain": knowledge_gain,
+            "cost": cost,
+            "noise": noise,
+            "repetition_penalty": repetition_penalty,
+            "raw_score": raw_score,
+        }
+
+        return raw_score, breakdown
 
     @staticmethod
     def _explain(cap: Capability, entity: Entity, score: float) -> str:

--- a/tests/test_decisions/test_decision.py
+++ b/tests/test_decisions/test_decision.py
@@ -1,0 +1,155 @@
+"""Tests for the decision model."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from basilisk.decisions.decision import ContextSnapshot, Decision, EvaluatedOption
+
+
+class TestContextSnapshot:
+    def test_defaults(self):
+        snap = ContextSnapshot()
+        assert snap.entity_count == 0
+        assert snap.step == 0
+        assert snap.elapsed_seconds == 0.0
+
+    def test_json_roundtrip(self):
+        snap = ContextSnapshot(entity_count=10, host_count=3, step=5)
+        data = snap.model_dump_json()
+        restored = ContextSnapshot.model_validate_json(data)
+        assert restored.entity_count == 10
+        assert restored.host_count == 3
+
+
+class TestEvaluatedOption:
+    def test_creation(self):
+        opt = EvaluatedOption(
+            capability_name="port_scan",
+            plugin_name="port_scan",
+            target_entity_id="abc123",
+            target_host="example.com",
+            score=0.75,
+            score_breakdown={"novelty": 1.0, "cost": 2.0},
+            was_chosen=True,
+        )
+        assert opt.capability_name == "port_scan"
+        assert opt.was_chosen is True
+        assert opt.score_breakdown["novelty"] == 1.0
+
+    def test_defaults(self):
+        opt = EvaluatedOption(
+            capability_name="test",
+            plugin_name="test",
+            target_entity_id="id1",
+            target_host="host",
+            score=0.5,
+        )
+        assert opt.score_breakdown == {}
+        assert opt.reason == ""
+        assert opt.was_chosen is False
+
+
+class TestDecision:
+    def test_make_id_deterministic(self):
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        id1 = Decision.make_id(1, ts, "port_scan", "example.com")
+        id2 = Decision.make_id(1, ts, "port_scan", "example.com")
+        assert id1 == id2
+        assert len(id1) == 16
+
+    def test_make_id_different_inputs(self):
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        id1 = Decision.make_id(1, ts, "port_scan", "a.com")
+        id2 = Decision.make_id(1, ts, "port_scan", "b.com")
+        assert id1 != id2
+
+    def test_make_id_different_steps(self):
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        id1 = Decision.make_id(1, ts, "port_scan", "a.com")
+        id2 = Decision.make_id(2, ts, "port_scan", "a.com")
+        assert id1 != id2
+
+    def test_creation_with_defaults(self):
+        d = Decision(id="test_id")
+        assert d.id == "test_id"
+        assert d.step == 0
+        assert d.outcome_observations == 0
+        assert d.was_productive is False
+        assert d.evaluated_options == []
+
+    def test_full_creation(self):
+        ts = datetime(2026, 2, 1, 12, 0, tzinfo=UTC)
+        d = Decision(
+            id=Decision.make_id(3, ts, "ssl_check", "target.com"),
+            timestamp=ts,
+            step=3,
+            goal="services",
+            goal_description="Host needs service scan",
+            goal_priority=10.0,
+            triggering_entity_id="ent_123",
+            context=ContextSnapshot(entity_count=5, step=3),
+            chosen_capability="ssl_check",
+            chosen_plugin="ssl_check",
+            chosen_target="target.com",
+            chosen_score=0.85,
+            reasoning_trace="High priority gap; ssl_check produces Service knowledge",
+        )
+        assert d.step == 3
+        assert d.context.entity_count == 5
+        assert d.reasoning_trace != ""
+
+    def test_json_roundtrip(self):
+        ts = datetime(2026, 2, 1, tzinfo=UTC)
+        d = Decision(
+            id=Decision.make_id(1, ts, "dns_enum", "ex.com"),
+            timestamp=ts,
+            step=1,
+            goal="dns",
+            chosen_capability="dns_enum",
+            chosen_plugin="dns_enum",
+            chosen_target="ex.com",
+            chosen_score=0.9,
+            evaluated_options=[
+                EvaluatedOption(
+                    capability_name="dns_enum",
+                    plugin_name="dns_enum",
+                    target_entity_id="h1",
+                    target_host="ex.com",
+                    score=0.9,
+                    was_chosen=True,
+                ),
+            ],
+            outcome_observations=5,
+            outcome_new_entities=3,
+            outcome_confidence_delta=0.15,
+            was_productive=True,
+        )
+        data = d.model_dump_json()
+        restored = Decision.model_validate_json(data)
+        assert restored.id == d.id
+        assert restored.step == 1
+        assert restored.chosen_score == 0.9
+        assert len(restored.evaluated_options) == 1
+        assert restored.evaluated_options[0].was_chosen is True
+        assert restored.outcome_new_entities == 3
+        assert restored.was_productive is True
+
+    def test_no_plugin_imports(self):
+        """Decision module must not import from plugin layer."""
+        import basilisk.decisions.decision as mod
+        source = mod.__file__
+        with open(source) as f:
+            content = f.read()
+        assert "basilisk.plugins" not in content
+        assert "BasePlugin" not in content
+
+    def test_outcome_update(self):
+        d = Decision(id="up_test", step=1)
+        assert d.was_productive is False
+        d.outcome_observations = 10
+        d.outcome_new_entities = 4
+        d.outcome_confidence_delta = 0.2
+        d.was_productive = True
+        assert d.was_productive is True
+        assert d.outcome_confidence_delta == 0.2

--- a/tests/test_knowledge/test_state.py
+++ b/tests/test_knowledge/test_state.py
@@ -1,0 +1,150 @@
+"""Tests for KnowledgeState delta tracking."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from basilisk.knowledge.entities import Entity, EntityType
+from basilisk.knowledge.graph import KnowledgeGraph
+from basilisk.knowledge.relations import Relation, RelationType
+from basilisk.knowledge.state import KnowledgeState, ObservationOutcome
+from basilisk.observations.observation import Observation
+from basilisk.orchestrator.planner import KnowledgeGap, Planner
+
+
+def _obs(
+    host: str = "test.com",
+    entity_type: EntityType = EntityType.SERVICE,
+    port: int = 80,
+    confidence: float = 0.8,
+) -> Observation:
+    return Observation(
+        entity_type=entity_type,
+        entity_data={"host": host, "port": port, "protocol": "tcp"},
+        key_fields={"host": host, "port": str(port), "protocol": "tcp"},
+        confidence=confidence,
+        source_plugin="test",
+    )
+
+
+class TestObservationOutcome:
+    def test_confidence_delta_positive(self):
+        o = ObservationOutcome(
+            entity_id="x", was_new=True,
+            confidence_before=0.0, confidence_after=0.8,
+        )
+        assert o.confidence_delta == 0.8
+
+    def test_confidence_delta_zero(self):
+        o = ObservationOutcome(
+            entity_id="x", was_new=False,
+            confidence_before=1.0, confidence_after=1.0,
+        )
+        assert o.confidence_delta == 0.0
+
+
+class TestKnowledgeStateApply:
+    def test_new_entity_returns_was_new(self):
+        graph = KnowledgeGraph()
+        state = KnowledgeState(graph)
+        outcome = state.apply_observation(_obs())
+        assert outcome.was_new is True
+        assert outcome.confidence_before == 0.0
+        assert outcome.confidence_after == 0.8
+
+    def test_duplicate_entity_merges_confidence(self):
+        graph = KnowledgeGraph()
+        state = KnowledgeState(graph)
+
+        outcome1 = state.apply_observation(_obs(confidence=0.6))
+        assert outcome1.was_new is True
+
+        outcome2 = state.apply_observation(_obs(confidence=0.6))
+        assert outcome2.was_new is False
+        assert outcome2.confidence_before == 0.6
+        # Probabilistic OR: 1 - (1-0.6)*(1-0.6) = 0.84
+        assert abs(outcome2.confidence_after - 0.84) < 0.01
+        assert outcome2.confidence_delta > 0
+
+    def test_graph_entity_count_increases(self):
+        graph = KnowledgeGraph()
+        state = KnowledgeState(graph)
+        state.apply_observation(_obs(host="a.com", port=80))
+        state.apply_observation(_obs(host="a.com", port=443))
+        assert graph.entity_count == 2
+
+    def test_same_entity_no_duplicate(self):
+        graph = KnowledgeGraph()
+        state = KnowledgeState(graph)
+        state.apply_observation(_obs())
+        state.apply_observation(_obs())
+        assert graph.entity_count == 1
+
+    def test_relation_applied(self):
+        graph = KnowledgeGraph()
+        host = Entity.host("rel.com")
+        graph.add_entity(host)
+        state = KnowledgeState(graph)
+
+        svc_id = Entity.make_id(EntityType.SERVICE, host="rel.com", port="80", protocol="tcp")
+        obs = Observation(
+            entity_type=EntityType.SERVICE,
+            entity_data={"host": "rel.com", "port": 80, "protocol": "tcp"},
+            key_fields={"host": "rel.com", "port": "80", "protocol": "tcp"},
+            relation=Relation(
+                source_id=host.id, target_id=svc_id, type=RelationType.EXPOSES,
+            ),
+            source_plugin="test",
+        )
+        state.apply_observation(obs)
+        assert graph.relation_count == 1
+
+
+class TestKnowledgeStateSnapshot:
+    def test_snapshot_values(self):
+        graph = KnowledgeGraph()
+        graph.add_entity(Entity.host("a.com"))
+        graph.add_entity(Entity.host("b.com"))
+        graph.add_entity(Entity.service("a.com", 80))
+
+        state = KnowledgeState(graph)
+        snap = state.snapshot(step=3, elapsed=12.5, gap_count=2)
+
+        assert snap.entity_count == 3
+        assert snap.host_count == 2
+        assert snap.service_count == 1
+        assert snap.step == 3
+        assert snap.elapsed_seconds == 12.5
+        assert snap.gap_count == 2
+
+    def test_snapshot_deterministic(self):
+        graph = KnowledgeGraph()
+        graph.add_entity(Entity.host("det.com"))
+        state = KnowledgeState(graph)
+
+        s1 = state.snapshot(1, 5.0, 0)
+        s2 = state.snapshot(1, 5.0, 0)
+        assert s1 == s2
+
+
+class TestKnowledgeStateFindGaps:
+    def test_delegates_to_planner(self):
+        graph = KnowledgeGraph()
+        planner = MagicMock(spec=Planner)
+        host = Entity.host("gap.com")
+        gap = KnowledgeGap(entity=host, missing="services", priority=10.0, description="test")
+        planner.find_gaps.return_value = [gap]
+
+        state = KnowledgeState(graph, planner=planner)
+        gaps = state.find_gaps()
+        assert len(gaps) == 1
+        assert gaps[0].missing == "services"
+        planner.find_gaps.assert_called_once_with(graph)
+
+    def test_without_planner_uses_graph(self):
+        graph = KnowledgeGraph()
+        graph.add_entity(Entity.host("noplanner.com"))
+        state = KnowledgeState(graph)
+        # Should not raise — delegates to graph.find_missing_knowledge()
+        gaps = state.find_gaps()
+        assert isinstance(gaps, list)

--- a/tests/test_memory/test_history.py
+++ b/tests/test_memory/test_history.py
@@ -1,0 +1,214 @@
+"""Tests for the decision history and repetition penalty."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from basilisk.decisions.decision import Decision
+from basilisk.memory.history import History
+
+
+def _decision(
+    step: int = 1,
+    plugin: str = "port_scan",
+    target: str = "example.com",
+    entity_id: str = "ent1",
+    productive: bool = False,
+) -> Decision:
+    ts = datetime(2026, 1, 1, step, 0, tzinfo=UTC)
+    d = Decision(
+        id=Decision.make_id(step, ts, plugin, target),
+        timestamp=ts,
+        step=step,
+        goal="services",
+        goal_description="test gap",
+        goal_priority=10.0,
+        triggering_entity_id=entity_id,
+        chosen_capability=plugin,
+        chosen_plugin=plugin,
+        chosen_target=target,
+        chosen_score=0.5,
+        reasoning_trace="test trace",
+    )
+    if productive:
+        d.outcome_new_entities = 3
+        d.outcome_confidence_delta = 0.2
+        d.was_productive = True
+    return d
+
+
+class TestHistoryRecord:
+    def test_record_increases_count(self):
+        h = History()
+        h.record(_decision())
+        assert len(h) == 1
+        h.record(_decision(step=2))
+        assert len(h) == 2
+
+    def test_decisions_property(self):
+        h = History()
+        d = _decision()
+        h.record(d)
+        assert h.decisions[0].id == d.id
+
+    def test_decisions_is_copy(self):
+        h = History()
+        h.record(_decision())
+        lst = h.decisions
+        lst.clear()
+        assert len(h) == 1
+
+
+class TestHistoryOutcome:
+    def test_update_outcome(self):
+        h = History()
+        d = _decision()
+        h.record(d)
+        h.update_outcome(
+            d.id,
+            observations=5,
+            new_entities=2,
+            confidence_delta=0.15,
+            duration=3.5,
+        )
+        assert d.outcome_observations == 5
+        assert d.outcome_new_entities == 2
+        assert d.outcome_confidence_delta == 0.15
+        assert d.outcome_duration == 3.5
+        assert d.was_productive is True
+
+    def test_update_unproductive(self):
+        h = History()
+        d = _decision()
+        h.record(d)
+        h.update_outcome(d.id, observations=0, new_entities=0, confidence_delta=0.0)
+        assert d.was_productive is False
+
+    def test_update_nonexistent_id(self):
+        h = History()
+        # Should not raise
+        h.update_outcome("nonexistent", observations=1)
+
+    def test_productive_count(self):
+        h = History()
+        h.record(_decision(step=1, productive=True))
+        h.record(_decision(step=2, productive=False))
+        h.record(_decision(step=3, productive=True))
+        assert h.productive_count == 2
+
+    def test_total_confidence_gained(self):
+        h = History()
+        d1 = _decision(step=1)
+        d2 = _decision(step=2)
+        h.record(d1)
+        h.record(d2)
+        h.update_outcome(d1.id, confidence_delta=0.1, new_entities=1)
+        h.update_outcome(d2.id, confidence_delta=0.25, new_entities=1)
+        assert abs(h.total_confidence_gained - 0.35) < 0.001
+
+
+class TestRepetitionPenalty:
+    def test_no_history_zero_penalty(self):
+        h = History()
+        p = h.repetition_penalty("port_scan", "ent1")
+        assert p == 0.0
+
+    def test_different_plugin_zero_penalty(self):
+        h = History()
+        h.record(_decision(plugin="dns_enum", entity_id="ent1"))
+        p = h.repetition_penalty("port_scan", "ent1")
+        assert p == 0.0
+
+    def test_different_target_zero_penalty(self):
+        h = History()
+        h.record(_decision(plugin="port_scan", entity_id="ent1"))
+        p = h.repetition_penalty("port_scan", "ent2")
+        assert p == 0.0
+
+    def test_same_plugin_target_has_penalty(self):
+        h = History()
+        h.record(_decision(plugin="port_scan", entity_id="ent1"))
+        p = h.repetition_penalty("port_scan", "ent1")
+        assert p > 0
+
+    def test_unproductive_higher_penalty(self):
+        h = History()
+        d = _decision(plugin="port_scan", entity_id="ent1", productive=False)
+        h.record(d)
+        p_unproductive = h.repetition_penalty("port_scan", "ent1")
+
+        h2 = History()
+        d2 = _decision(plugin="port_scan", entity_id="ent1", productive=True)
+        h2.record(d2)
+        p_productive = h2.repetition_penalty("port_scan", "ent1")
+
+        assert p_unproductive > p_productive
+
+    def test_penalty_decays_with_steps(self):
+        h = History()
+        h.record(_decision(step=1, plugin="port_scan", entity_id="ent1"))
+        p_immediate = h.repetition_penalty("port_scan", "ent1")
+
+        # Add many decisions after to simulate time passing
+        for i in range(2, 22):
+            h.record(_decision(step=i, plugin="dns_enum", entity_id=f"other_{i}"))
+
+        p_later = h.repetition_penalty("port_scan", "ent1")
+        assert p_later < p_immediate
+
+
+class TestHistoryPersistence:
+    def test_save_and_load(self, tmp_path: Path):
+        h = History()
+        d = _decision(step=1, productive=True)
+        h.record(d)
+        h.update_outcome(d.id, observations=3, new_entities=2, confidence_delta=0.1, duration=1.0)
+
+        path = tmp_path / "history.json"
+        h.save(path)
+        assert path.exists()
+
+        loaded = History.load(path)
+        assert len(loaded) == 1
+        assert loaded.decisions[0].id == d.id
+        assert loaded.decisions[0].outcome_observations == 3
+        assert loaded.decisions[0].was_productive is True
+
+    def test_load_nonexistent_returns_empty(self, tmp_path: Path):
+        path = tmp_path / "missing.json"
+        loaded = History.load(path)
+        assert len(loaded) == 0
+
+    def test_roundtrip_preserves_all_fields(self, tmp_path: Path):
+        h = History()
+        d = _decision(step=5, plugin="ssl_check", target="t.com", entity_id="e5")
+        d.reasoning_trace = "Custom reasoning"
+        h.record(d)
+        h.update_outcome(d.id, observations=10, new_entities=5, confidence_delta=0.3, duration=2.5)
+
+        path = tmp_path / "rt.json"
+        h.save(path)
+        loaded = History.load(path)
+
+        rd = loaded.decisions[0]
+        assert rd.step == 5
+        assert rd.chosen_plugin == "ssl_check"
+        assert rd.reasoning_trace == "Custom reasoning"
+        assert rd.outcome_observations == 10
+        assert rd.outcome_confidence_delta == 0.3
+
+
+class TestHistorySummary:
+    def test_empty_summary(self):
+        h = History()
+        assert "No decisions" in h.summary()
+
+    def test_summary_format(self):
+        h = History()
+        h.record(_decision(step=1, productive=True))
+        h.record(_decision(step=2, productive=False))
+        s = h.summary()
+        assert "2 decisions" in s
+        assert "1 productive" in s
+        assert "50%" in s

--- a/tests/test_orchestrator/test_safety.py
+++ b/tests/test_orchestrator/test_safety.py
@@ -34,3 +34,25 @@ class TestSafetyLimits:
         safety.start()
         time.sleep(0.01)
         assert safety.elapsed > 0
+
+
+class TestCooldown:
+    def test_cooled_down_when_never_run(self):
+        safety = SafetyLimits(cooldown_per_capability=10.0)
+        assert safety.is_cooled_down("plugin:entity") is True
+
+    def test_not_cooled_down_immediately(self):
+        safety = SafetyLimits(cooldown_per_capability=10.0)
+        safety.record_run("plugin:entity")
+        assert safety.is_cooled_down("plugin:entity") is False
+
+    def test_cooled_down_after_wait(self):
+        safety = SafetyLimits(cooldown_per_capability=0.01)
+        safety.record_run("plugin:entity")
+        time.sleep(0.02)
+        assert safety.is_cooled_down("plugin:entity") is True
+
+    def test_no_cooldown_when_zero(self):
+        safety = SafetyLimits(cooldown_per_capability=0.0)
+        safety.record_run("plugin:entity")
+        assert safety.is_cooled_down("plugin:entity") is True


### PR DESCRIPTION
## Summary

- **Decision tracing**: every autonomous action now produces an explainable `Decision` record with context snapshot, evaluated alternatives, reasoning trace, and post-execution outcome metrics
- **KnowledgeState**: delta-tracking wrapper around KnowledgeGraph — `apply_observation()` returns `ObservationOutcome` with real confidence deltas (was hardcoded `0.0`)
- **Memory/History**: decision log with adaptive repetition penalty (base × time_decay × unproductive_multiplier) replacing the binary 5.0, plus JSON persistence
- **Scorer breakdown**: `score_breakdown` dict with all 6 scoring components for full transparency
- **Safety cooldown**: `record_run()` / `is_cooled_down()` enforcement in the autonomous loop
- **DECISION_MADE event**: new event type emitted before each plugin execution

## New files (7)

| File | Purpose |
|------|---------|
| `basilisk/decisions/decision.py` | `Decision`, `ContextSnapshot`, `EvaluatedOption` models |
| `basilisk/knowledge/state.py` | `KnowledgeState`, `ObservationOutcome` — delta tracking |
| `basilisk/memory/history.py` | `History` — decision log, penalty, persistence |
| `tests/test_decisions/test_decision.py` | 12 tests |
| `tests/test_knowledge/test_state.py` | 11 tests |
| `tests/test_memory/test_history.py` | 19 tests |

## Modified files (8)

| File | Change |
|------|--------|
| `scoring/scorer.py` | +`score_breakdown`, optional `History` |
| `events/bus.py` | +`DECISION_MADE` |
| `orchestrator/safety.py` | +cooldown tracking |
| `orchestrator/loop.py` | Decision traces, KnowledgeState, real confidence deltas |
| `core/facade.py` | Wire History, save `decision_history.json` |
| 3 test files | +17 tests for scorer, safety, loop |

## Test plan

- [x] 1441 tests pass (was 1382, +59 new)
- [x] Ruff clean on all new/modified files
- [x] Pipeline mode completely unaffected (backward compat)
- [x] Decision JSON roundtrip works
- [x] Repetition penalty decays over time, doubles for unproductive runs
- [x] Cooldown blocks recent re-execution
- [x] `confidence_delta` is no longer 0.0 for productive steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)